### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Latest Stable Version](https://poser.pugx.org/infonique/newt/v/stable.svg)](https://extensions.typo3.org/extension/newt/)
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/infonique/newt/d/total.svg)](https://packagist.org/packages/infonique/newt)
+[![Monthly Downloads](https://poser.pugx.org/infonique/newt/d/monthly)](https://packagist.org/packages/infonique/newt)
+
 # TYPO3 extension `newt`
 
 This TYPO3 extension implements the [NEWT REST API](https://documenter.getpostman.com/view/14469363/UVsHT7RW) and allows you to manage your

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Latest Stable Version](https://poser.pugx.org/infonique/newt/v/stable.svg)](https://extensions.typo3.org/extension/newt/)
 [![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
 [![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
-[![Total Downloads](https://poser.pugx.org/infonique/newt/d/total.svg)](https://packagist.org/packages/infonique/newt)
+[![Total Downloads](https://poser.pugx.org/infonique/newt/d/total)](https://packagist.org/packages/infonique/newt)
 [![Monthly Downloads](https://poser.pugx.org/infonique/newt/d/monthly)](https://packagist.org/packages/infonique/newt)
 
 # TYPO3 extension `newt`

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "infonique/newt",
     "type": "typo3-cms-extension",
     "description": "Backend-Extension to manage the Newt-Access",
+	"homepage": "https://extensions.typo3.org/extension/newt",
+	"support": {
+		"docs": "https://docs.typo3.org/p/infonique/newt/main/en-us/",
+		"issues": "https://github.com/juergenfurrer/newt-typo3-ext/issues",
+		"source": "https://github.com/juergenfurrer/newt-typo3-ext"
+	},
     "authors": [
         {
             "name": "Juergen Furrer",


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

Relates: TYPO3-Documentation/T3DocTeam#185